### PR TITLE
add proTransfer parameter

### DIFF
--- a/WalletKit/src/main/java/com/blockset/walletkit/SystemClient.java
+++ b/WalletKit/src/main/java/com/blockset/walletkit/SystemClient.java
@@ -297,6 +297,7 @@ public interface SystemClient {
                                   @Nullable String exchangeId,
                                   @Nullable String secondFactorCode,
                                   @Nullable String secondFactorBackup,
+                                  @Nullable String proTransfer,
                                   boolean isSweep,
                                   CompletionHandler<TransactionIdentifier, SystemClientError> handler);
 

--- a/WalletKit/src/main/java/com/blockset/walletkit/Wallet.java
+++ b/WalletKit/src/main/java/com/blockset/walletkit/Wallet.java
@@ -30,22 +30,22 @@ public interface Wallet {
     //Optional<? extends TransferFeeBasis> createTransferFeeBasis(Amount pricePerCostFactor, double costFactor);
 
     default Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes) {
-        return createTransfer(target, amount, estimatedFeeBasis, attributes, null, null, null, false);
+        return createTransfer(target, amount, estimatedFeeBasis, attributes, null, null, null, null,false);
     }
 
     Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId);
 
-    Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup);
+    Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer);
 
-    Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, boolean isSweep);
+    Optional<? extends Transfer> createTransfer(Address target, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer, boolean isSweep);
 
     @Nullable String getAddressFromScript(@Nullable String outputScript);
 
     Optional<? extends Transfer> createTransfer(@Nullable String outputScript, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId);
 
-    Optional<? extends Transfer> createTransfer(@Nullable String outputScript, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup);
+    Optional<? extends Transfer> createTransfer(@Nullable String outputScript, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer);
 
-    Optional<? extends Transfer> createTransfer(@Nullable String outputScript, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, boolean isSweep);
+    Optional<? extends Transfer> createTransfer(@Nullable String outputScript, Amount amount, TransferFeeBasis estimatedFeeBasis, @Nullable Set<TransferAttribute> attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer, boolean isSweep);
 
     /**
      * Estimate the fee for a transfer with `amount` from `wallet`.  If provided use the `feeBasis`

--- a/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/System.java
+++ b/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/System.java
@@ -1759,6 +1759,7 @@ final class System implements com.blockset.walletkit.System {
                                           @Nullable String exchangeId,
                                           @Nullable String secondFactorCode,
                                           @Nullable String secondFactorBackup,
+                                          @Nullable String proTransfer,
                                           boolean isSweep,
                                           byte[] transaction) {
         EXECUTOR_CLIENT.execute(() -> {
@@ -1775,7 +1776,7 @@ final class System implements com.blockset.walletkit.System {
                 System        system   = optExtraction.get().system;
                 WalletManager manager  = optExtraction.get().manager;
 
-                system.query.createTransaction(manager.getNetwork().getUids(), transaction, identifier, exchangeId, secondFactorCode, secondFactorBackup, isSweep,
+                system.query.createTransaction(manager.getNetwork().getUids(), transaction, identifier, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, isSweep,
                         new CompletionHandler<TransactionIdentifier, SystemClientError>() {
                             @Override
                             public void handleData(TransactionIdentifier tid) {

--- a/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/Wallet.java
+++ b/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/Wallet.java
@@ -122,29 +122,7 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                 coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
             }
 
-        return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes, exchangeId, null, null, false)
-                .transform(t -> Transfer.create(t, this, false));
-    }
-
-    @Override
-    public Optional<Transfer> createTransfer(com.blockset.walletkit.Address target,
-                                             com.blockset.walletkit.Amount amount,
-                                             com.blockset.walletkit.TransferFeeBasis estimatedFeeBasis,
-                                             @Nullable Set<com.blockset.walletkit.TransferAttribute> attributes,
-                                             @Nullable String exchangeId,
-                                             @Nullable String secondFactorCode,
-                                             @Nullable String secondFactorBackup) {
-        WKAddress coreAddress = Address.from(target).getCoreBRCryptoAddress();
-        WKFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
-        WKAmount coreAmount = Amount.from(amount).getCoreBRCryptoAmount();
-
-        List<WKTransferAttribute> coreAttributes = new ArrayList<>();
-        if (null != attributes)
-            for (com.blockset.walletkit.TransferAttribute attribute : attributes) {
-                coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
-            }
-
-        return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, false)
+        return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes, exchangeId, null, null, null, false)
                 .transform(t -> Transfer.create(t, this, false));
     }
 
@@ -156,6 +134,30 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                                              @Nullable String exchangeId,
                                              @Nullable String secondFactorCode,
                                              @Nullable String secondFactorBackup,
+                                             @Nullable String proTransfer) {
+        WKAddress coreAddress = Address.from(target).getCoreBRCryptoAddress();
+        WKFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
+        WKAmount coreAmount = Amount.from(amount).getCoreBRCryptoAmount();
+
+        List<WKTransferAttribute> coreAttributes = new ArrayList<>();
+        if (null != attributes)
+            for (com.blockset.walletkit.TransferAttribute attribute : attributes) {
+                coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
+            }
+
+        return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, false)
+                .transform(t -> Transfer.create(t, this, false));
+    }
+
+    @Override
+    public Optional<Transfer> createTransfer(com.blockset.walletkit.Address target,
+                                             com.blockset.walletkit.Amount amount,
+                                             com.blockset.walletkit.TransferFeeBasis estimatedFeeBasis,
+                                             @Nullable Set<com.blockset.walletkit.TransferAttribute> attributes,
+                                             @Nullable String exchangeId,
+                                             @Nullable String secondFactorCode,
+                                             @Nullable String secondFactorBackup,
+                                             @Nullable String proTransfer,
                                              boolean isSweep) {
         WKAddress coreAddress = Address.from(target).getCoreBRCryptoAddress();
         WKFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
@@ -167,7 +169,7 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                 coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
             }
 
-        return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, isSweep)
+        return core.createTransfer(coreAddress, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, isSweep)
                 .transform(t -> Transfer.create(t, this, false));
     }
 
@@ -192,28 +194,7 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                 coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
             }
 
-        return core.createTransfer(outputScript, coreAmount, coreFeeBasis, coreAttributes, exchangeId, null, null, false)
-                .transform(t -> Transfer.create(t, this, false));
-    }
-
-    @Override
-    public Optional<Transfer> createTransfer(@Nullable String outputScript,
-                                             com.blockset.walletkit.Amount amount,
-                                             com.blockset.walletkit.TransferFeeBasis estimatedFeeBasis,
-                                             @Nullable Set<com.blockset.walletkit.TransferAttribute> attributes,
-                                             @Nullable String exchangeId,
-                                             @Nullable String secondFactorCode,
-                                             @Nullable String secondFactorBackup) {
-        WKFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
-        WKAmount coreAmount = Amount.from(amount).getCoreBRCryptoAmount();
-
-        List<WKTransferAttribute> coreAttributes = new ArrayList<>();
-        if (null != attributes)
-            for (com.blockset.walletkit.TransferAttribute attribute : attributes) {
-                coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
-            }
-
-        return core.createTransfer(outputScript, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, false)
+        return core.createTransfer(outputScript, coreAmount, coreFeeBasis, coreAttributes, exchangeId, null, null, null, false)
                 .transform(t -> Transfer.create(t, this, false));
     }
 
@@ -225,6 +206,29 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                                              @Nullable String exchangeId,
                                              @Nullable String secondFactorCode,
                                              @Nullable String secondFactorBackup,
+                                             @Nullable String proTransfer) {
+        WKFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
+        WKAmount coreAmount = Amount.from(amount).getCoreBRCryptoAmount();
+
+        List<WKTransferAttribute> coreAttributes = new ArrayList<>();
+        if (null != attributes)
+            for (com.blockset.walletkit.TransferAttribute attribute : attributes) {
+                coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
+            }
+
+        return core.createTransfer(outputScript, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, false)
+                .transform(t -> Transfer.create(t, this, false));
+    }
+
+    @Override
+    public Optional<Transfer> createTransfer(@Nullable String outputScript,
+                                             com.blockset.walletkit.Amount amount,
+                                             com.blockset.walletkit.TransferFeeBasis estimatedFeeBasis,
+                                             @Nullable Set<com.blockset.walletkit.TransferAttribute> attributes,
+                                             @Nullable String exchangeId,
+                                             @Nullable String secondFactorCode,
+                                             @Nullable String secondFactorBackup,
+                                             @Nullable String proTransfer,
                                              boolean isSweep) {
         WKFeeBasis coreFeeBasis = TransferFeeBasis.from(estimatedFeeBasis).getCoreBRFeeBasis();
         WKAmount coreAmount = Amount.from(amount).getCoreBRCryptoAmount();
@@ -235,7 +239,7 @@ final class Wallet implements com.blockset.walletkit.Wallet {
                 coreAttributes.add (TransferAttribute.from(attribute).getCoreBRCryptoTransferAttribute());
             }
 
-        return core.createTransfer(outputScript, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, isSweep)
+        return core.createTransfer(outputScript, coreAmount, coreFeeBasis, coreAttributes, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, isSweep)
                 .transform(t -> Transfer.create(t, this, false));
     }
 

--- a/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/systemclient/BlocksetSystemClient.java
+++ b/WalletKitBRD/src/main/java/com/blockset/walletkit/brd/systemclient/BlocksetSystemClient.java
@@ -453,6 +453,7 @@ public class BlocksetSystemClient implements SystemClient {
                                   @Nullable String exchangeId,
                                   @Nullable String secondFactorCode,
                                   @Nullable String secondFactorBackup,
+                                  @Nullable String proTransfer,
                                   boolean isSweep,
                                   CompletionHandler<TransactionIdentifier, SystemClientError> handler) {
         String data = BaseEncoding.base64().encode(tx);
@@ -471,6 +472,10 @@ public class BlocksetSystemClient implements SystemClient {
 
         if (secondFactorBackup != null) {
             params.put("second_factor_backup", secondFactorBackup);
+        }
+
+        if (proTransfer != null) {
+            params.put("pro_transfer", proTransfer);
         }
 
         params.put("is_sweep", String.valueOf(isSweep));

--- a/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKClient.java
+++ b/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKClient.java
@@ -58,6 +58,7 @@ public class WKClient extends Structure {
                       String exchangeId,
                       String secondFactorCode,
                       String secondFactorBackup,
+                      String proTransfer,
                       boolean isSweep,
                       Pointer tx,
                       SizeT txLength);
@@ -162,6 +163,7 @@ public class WKClient extends Structure {
                     String exchangeId,
                     String secondFactorCode,
                     String secondFactorBackup,
+                    String proTransfer,
                     boolean isSweep,
                     byte[] transaction);
 
@@ -173,6 +175,7 @@ public class WKClient extends Structure {
                               String exchangeId,
                               String secondFactorCode,
                               String secondFactorBackup,
+                              String proTransfer,
                               boolean isSweep,
                               Pointer tx,
                               SizeT txLength) {
@@ -184,6 +187,7 @@ public class WKClient extends Structure {
                     exchangeId,
                     secondFactorCode,
                     secondFactorBackup,
+                    proTransfer,
                     isSweep,
                     tx.getByteArray(0, UnsignedInts.checkedCast(txLength.longValue()))
             );

--- a/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKWallet.java
+++ b/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/WKWallet.java
@@ -192,6 +192,7 @@ public class WKWallet extends PointerType {
                                                @Nullable String exchangeId,
                                                @Nullable String secondFactorCode,
                                                @Nullable String secondFactorBackup,
+                                               @Nullable String proTransfer,
                                                boolean isSweep) {
         Pointer thisPtr = this.getPointer();
 
@@ -210,6 +211,7 @@ public class WKWallet extends PointerType {
                         exchangeId,
                         secondFactorCode,
                         secondFactorBackup,
+                        proTransfer,
                         isSweep
                 )
         ).transform(WKTransfer::new);
@@ -236,6 +238,7 @@ public class WKWallet extends PointerType {
                                                @Nullable String exchangeId,
                                                @Nullable String secondFactorCode,
                                                @Nullable String secondFactorBackup,
+                                               @Nullable String proTransfer,
                                                boolean isSweep) {
         Pointer thisPtr = this.getPointer();
 
@@ -254,6 +257,7 @@ public class WKWallet extends PointerType {
                         exchangeId,
                         secondFactorCode,
                         secondFactorBackup,
+                        proTransfer,
                         isSweep
                 )
         ).transform(WKTransfer::new);

--- a/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/library/WKNativeLibraryIndirect.java
+++ b/WalletKitNative/src/main/java/com/blockset/walletkit/nativex/library/WKNativeLibraryIndirect.java
@@ -38,18 +38,18 @@ public final class WKNativeLibraryIndirect {
         INSTANCE.wkNetworkSetNetworkFees(network, fees, count);
     }
 
-    public static Pointer wkWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, Boolean isSweep) {
+    public static Pointer wkWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer, Boolean isSweep) {
         attributes = attributesCount.intValue() == 0 ? null : attributes;
-        return INSTANCE.wkWalletCreateTransfer(wallet, target, amount, feeBasis, attributesCount, attributes, exchangeId, secondFactorCode, secondFactorBackup, isSweep);
+        return INSTANCE.wkWalletCreateTransfer(wallet, target, amount, feeBasis, attributesCount, attributes, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, isSweep);
     }
 
     public static void wkWalletGetAddressFromScript(Pointer wallet, @Nullable String outputScript, byte[] addressBuffer, SizeT addressBufferSize) {
         INSTANCE.wkWalletGetAddressFromScript(wallet, outputScript, addressBuffer, addressBufferSize);
     }
 
-    public static Pointer wkWalletCreateTransferFromScript(Pointer wallet, @Nullable String outputScript, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, Boolean isSweep) {
+    public static Pointer wkWalletCreateTransferFromScript(Pointer wallet, @Nullable String outputScript, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer, Boolean isSweep) {
         attributes = attributesCount.intValue() == 0 ? null : attributes;
-        return INSTANCE.wkWalletCreateTransferFromScript(wallet, outputScript, amount, feeBasis, attributesCount, attributes, exchangeId, secondFactorCode, secondFactorBackup, isSweep);
+        return INSTANCE.wkWalletCreateTransferFromScript(wallet, outputScript, amount, feeBasis, attributesCount, attributes, exchangeId, secondFactorCode, secondFactorBackup, proTransfer, isSweep);
     }
 
     public static int wkWalletValidateTransferAttributes(Pointer wallet, SizeT attributesCount, WKTransferAttribute[] attributes, IntByReference validates) {
@@ -208,11 +208,11 @@ public final class WKNativeLibraryIndirect {
         void wkNetworkSetNetworkFees(Pointer network, WKNetworkFee[] fees, SizeT count);
 
         // crypto/BRCryptoWallet.h
-        Pointer wkWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, Boolean isSweep);
+        Pointer wkWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer, Boolean isSweep);
 
         void wkWalletGetAddressFromScript(Pointer wallet, @Nullable String outputScript, byte[] addressBuffer, SizeT addressBufferSize);
 
-        Pointer wkWalletCreateTransferFromScript(Pointer wallet, @Nullable String outputScript, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, Boolean isSweep);
+        Pointer wkWalletCreateTransferFromScript(Pointer wallet, @Nullable String outputScript, Pointer amount, Pointer feeBasis, SizeT attributesCount, WKTransferAttribute[] attributes, @Nullable String exchangeId, @Nullable String secondFactorCode, @Nullable String secondFactorBackup, @Nullable String proTransfer, Boolean isSweep);
 
         int wkWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, WKTransferAttribute[] attributes, IntByReference validates);
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    wkVersion = '5.0.28'
+    wkVersion = '5.0.29'
 }
 
 buildscript {


### PR DESCRIPTION
Added necessary code to send the pro_transfer parameter to the backend. The parameter is optional and can be added when calling wallet.createTransfer(... proTransfer_value ...) from the client app.